### PR TITLE
Include hk minor/patch updates in grouped mise renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,8 +26,18 @@
       "matchManagers": [
         "mise"
       ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "mise",
+      "schedule": [
+        "on monday"
+      ]
+    },
+    {
       "matchDepNames": [
-        "!hk"
+        "hk-pkl"
       ],
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
mise マネージャーのグループ化ルールから `matchDepNames: ["!hk"]` を削除し、hk を含む全 mise の minor/patch 更新を `mise` グループにまとめる。あわせて `hk-pkl` の minor/patch 更新も同じ `mise` グループに含める新ルールを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)