### PR TITLE
Fix invalid Handlebars template in Renovate group.commitMessageTopic

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
   "minimumReleaseAge": "2 days",
   "osvVulnerabilityAlerts": true,
   "group": {
-    "commitMessageTopic": "{{#if upgrades.1}}{{{groupName}}}{{else}}{{{depName}}}{{/if}}"
+    "commitMessageTopic": "{{#if upgrades.[1]}}{{{groupName}}}{{else}}{{{depName}}}{{/if}}"
   },
   "customManagers": [
     {


### PR DESCRIPTION
## 概要

Renovate設定が無効でPR作成が停止していた問題 (#37) を修正します。

`group.commitMessageTopic` の `{{#if upgrades.1}}` がHandlebarsのパースエラーになっていました。数字で始まるパスセグメントはセグメントリテラル記法 `[1]` が必須で、`upgrades.1` のままではテンプレートのバリデーションに失敗し、Renovateが設定全体を拒否していました。

`upgrades.[1]` に修正することで、複数依存のグループでは `groupName`、単一依存では `depName` を表示する元の意図どおりに動作します。

## 検証

`renovate-config-validator` で `Config validated successfully` を確認済み。

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)