### PR TITLE
Schedule dprint plugin updates weekly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -67,6 +67,18 @@
     },
     {
       "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "dprint.json"
+      ],
+      "groupName": "dprint plugins",
+      "schedule": [
+        "* * * * 1"
+      ]
+    },
+    {
+      "matchManagers": [
         "github-actions"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
The dprint plugins group comes from the shared renovate-config preset, which sets no schedule, so plugin releases arrived as individual PRs. Align it with the other groups in this repo by running it on Mondays.